### PR TITLE
Agregar gitignore y modifica mensaje

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#Archivo del Token del Bot
+config.json

--- a/events/ready.js
+++ b/events/ready.js
@@ -4,6 +4,6 @@ module.exports = {
 	name: Events.ClientReady,
 	once: true,
 	execute(client) {
-		console.log(`¡Listo! Has iniciado sesión como: ${client.user.tag}`);
+		console.log(`¡Listo! Has iniciado sesión como: ${client.user.tag}.\\Este es un servicio brindado por Paradise Chile Network.`);
 	},
 };


### PR DESCRIPTION
Agregar gitignore para hacer más fácil los testeos sin arriesgar el Token del Bot, así como agregar más información al mensaje de bienvenida una vez se activa el Bot.